### PR TITLE
fix: add "mouseWheel" event

### DIFF
--- a/projects/lib/src/lib/fabric.component.ts
+++ b/projects/lib/src/lib/fabric.component.ts
@@ -56,6 +56,7 @@ export class FabricComponent implements AfterViewInit {
   @Output() mouseOver = new EventEmitter<any>();
   @Output() mouseOut = new EventEmitter<any>();
   @Output() mouseMove = new EventEmitter<any>();
+  @Output() mouseWheel = new EventEmitter<any>();
   @Output() mouseDblclick = new EventEmitter<any>();
   @Output() mouseUpBefore = new EventEmitter<any>();
   @Output() mouseDownBefore = new EventEmitter<any>();

--- a/projects/lib/src/lib/fabric.directive.ts
+++ b/projects/lib/src/lib/fabric.directive.ts
@@ -66,6 +66,7 @@ export class FabricDirective implements OnInit, OnDestroy, DoCheck, OnChanges {
   @Output() mouseOver = new EventEmitter<any>();
   @Output() mouseOut = new EventEmitter<any>();
   @Output() mouseMove = new EventEmitter<any>();
+  @Output() mouseWheel = new EventEmitter<any>();
   @Output() mouseDblclick = new EventEmitter<any>();
   @Output() mouseUpBefore = new EventEmitter<any>();
   @Output() mouseDownBefore = new EventEmitter<any>();

--- a/projects/lib/src/lib/fabric.interfaces.ts
+++ b/projects/lib/src/lib/fabric.interfaces.ts
@@ -5,11 +5,11 @@ export const FABRIC_CONFIG = new InjectionToken<FabricConfigInterface>('FABRIC_C
 export type FabricEvent = 'drop' | 'dragover' | 'dragenter' | 'dragleave' | 'mouseup' |
   'mousedown' | 'mouseover' | 'mouseout' | 'mousemove' | 'mousewheel' | 'mousedblclick' |
   'mouseupBefore' | 'mousedownBefore' | 'mousemoveBefore' | 'mouseUp' | 'mouseDown' |
-  'mouseOver' | 'mouseOut' | 'mouseMove' | 'mouseDblclick' | 'mouseUpBefore' | 'mouseDownBefore' |
+  'mouseOver' | 'mouseOut' | 'mouseMove' | 'mouseWheel' | 'mouseDblclick' | 'mouseUpBefore' | 'mouseDownBefore' |
   'mouseMoveBefore' | 'pathCreated' | 'alterRender' | 'objectAdded' | 'objectMoved' | 'objectScaled' |
   'objectSkewed' | 'objectRotated' | 'objectRemoved' | 'objectModified' | 'objectSelected' |
   'objectMoving' | 'objectScaling' | 'objectSkewing' | 'objectRotating' | 'selectionCleared' |
-  'selectionCreated' | 'selectionUpdated' | 'beforeTransform' | 'beforeSelectionCleared';
+  'selectionCreated' | 'selectionUpdated' | 'beforeTransform' | 'beforeSelectionCleared' ;
 
 export const FabricEvents: FabricEvent[] = [
   'drop',
@@ -33,6 +33,7 @@ export const FabricEvents: FabricEvent[] = [
   'mouseOver',
   'mouseOut',
   'mouseMove',
+  'mouseWheel',
   'mouseDblclick',
   'mouseUpBefore',
   'mouseDownBefore',


### PR DESCRIPTION
because native event does not trigger well enough ( upper-canvas prevents from using native elements).

I noticed that the `on()` method for the mousewheel is not firing, because there is an additional element with css class `upper-canvas`as overlay of the "real" canvas. so I tried to add the mouseWheel event ( because there is none with capital W ), and then it did work with the observables!

Would be awesome if you could publish the fix soonish, because we would use your library then in a project and may contribute more often then :) 

Greetings,
Alex